### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ nsfwjs.load().then(function (model) {
 
 #### `load` the model
 
-Before you can classify any images, you'll need to load the model. For many reasons, you should use the optional parameter and load the model from your website. Review how in the install directions.
+Before you can classify any image, you'll need to load the model. You should use the optional parameter and load the model from your website, as explained in the install directions.
 
 ```js
 const model = nsfwjs.load('/path/to/model/directory/')


### PR DESCRIPTION
- "Before you can classify any images..." -> "Before you can classify any image..."
- Remove "For many reasons". If the reasons are not going to be explained, mentioning them is redundant.
- "...load the model from your website. Review how in the install directions." -> "...load the model from your website, as explained in the install directions."