### PR TITLE
update className's type as literal type instead of string type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ interface nsfwjsOptions {
 }
 
 export type predictionType = {
-  className: string
+  className: typeof NSFW_CLASSES[keyof typeof NSFW_CLASSES]
   probability: number
 }
 

--- a/src/nsfw_classes.ts
+++ b/src/nsfw_classes.ts
@@ -1,4 +1,4 @@
-export const NSFW_CLASSES: {[classId: number]: string} = {
+export const NSFW_CLASSES: {[classId: number]: 'Drawing' | 'Hentai' | 'Neutral' | 'Porn' | 'Sexy'} = {
   0: 'Drawing',
   1: 'Hentai',
   2: 'Neutral',


### PR DESCRIPTION
Since className can only be 'Drawing' | 'Hentai' | 'Neutral' | 'Porn' | 'Sexy', I think it's better that className's type is a literal type rather than string type.  
Using literal type instead of string type can also have better dev experience:
![vscode dev experience](https://user-images.githubusercontent.com/37903575/105070837-d217e700-5abe-11eb-937e-b86f61edf55c.png)
I won't make a typo, like writing "Natural" instead of "Neutral" to make expression always be false.
