### PR TITLE
Support loading from indexeddb:// or localstorage://

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,14 @@ Model example - [Graph](https://github.com/infinitered/nsfwjs/tree/master/exampl
 const model = nsfwjs.load('/path/to/different/model/', { type: 'graph' })
 ```
 
+If you're using in the browser and you'd like to subsequently load from indexed db or local storage you can save the underlying model using the appropriate scheme and load from there.
+
+```js
+const initialLoad = await nsfwjs.load('/path/to/different/model')
+await initialLoad.model.save('indexeddb://model')
+const model = await nsfwjs.load('indexeddb://model')
+```
+
 **Parameters**
 
 - optional URL to the `model.json` folder.

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,12 +50,11 @@ interface IOHandler {
 
 export class NSFWJS {
   public endpoints: string[];
+  public model: tf.LayersModel | tf.GraphModel;
 
   private options: nsfwjsOptions;
   private pathOrIOHandler: string | IOHandler;
-  private model: tf.LayersModel | tf.GraphModel;
   private intermediateModels: { [layerName: string]: tf.LayersModel } = {};
-
   private normalizationOffset: tf.Scalar;
 
   constructor(

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,11 @@ export class NSFWJS {
     this.options = options;
     this.normalizationOffset = tf.scalar(255);
 
-    if (typeof modelPathBaseOrIOHandler === "string") {
+    if (
+      typeof modelPathBaseOrIOHandler === "string" &&
+      !modelPathBaseOrIOHandler.startsWith("indexeddb://") &&
+      !modelPathBaseOrIOHandler.startsWith("localstorage://")
+    ) {  
       this.pathOrIOHandler = `${modelPathBaseOrIOHandler}model.json`;
     } else {
       this.pathOrIOHandler = modelPathBaseOrIOHandler;


### PR DESCRIPTION
Addresses: https://github.com/infinitered/nsfwjs/issues/430

* Updates NSFWJS constructor to support indexeddb:// and localstorage:// model paths. 
* Exposes underlying TFJS model as public property (formerly private)
* Adds example to README of how to save and load from indexeddb:// path

I tried adding tests but TFJS doesn't define a handler for indexed db or local storage [if you're not running in a browser environment](https://github.com/tensorflow/tfjs/blob/7693f4d487d534945cc5cec90c6e759de71e2797/tfjs-core/src/io/indexed_db.ts#L212). They have mocking for their own tests which I tried to follow but without any luck. 