### PR TITLE
fix: Load tfjs model over https instead of http

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ export type predictionType = {
 
 const BASE_PATH =
   // OLD S3 "https://s3.amazonaws.com/ir_public/nsfwjscdn/TFJS_nsfw_mobilenet/tfjs_quant_nsfw_mobilenet/";
-  "http://d1zv2aa70wpiur.cloudfront.net/tfjs_quant_nsfw_mobilenet/";
+  "https://d1zv2aa70wpiur.cloudfront.net/tfjs_quant_nsfw_mobilenet/";
 const IMAGE_SIZE = 224; // default to Mobilenet v2
 
 export async function load(base = BASE_PATH, options = { size: IMAGE_SIZE }) {


### PR DESCRIPTION
This also requires an additional change in order to function properly, CORS must be allowed from all origins (`*`) so that the model can be loaded on any website (as mentioned in #524 )