### PR TITLE
Update README for decoding image in UInt8 Byte array

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ let _model
 
 const convert = async (img) => {
   // Decoded image in UInt8 Byte array
-  const image = await jpeg.decode(img, true)
+  const image = await jpeg.decode(img, { useTArray: true })
 
   const numChannels = 3
   const numPixels = image.width * image.height


### PR DESCRIPTION
Regarding the official documentation for jpeg-js (https://github.com/jpeg-js/jpeg-js), to decode image into Uint8Array, we should pass an object as second parameter for decode() method with `useTArray: true`.