### PR TITLE
Restricting `shipit` command to only be run with `npm run shipit` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "test": "yarn build && jest",
     "lint": "tslint -p . -t verbose",
-    "shipit": "yarn build && yarn scriptbundle && yarn minbundle && np",
+    "shipit:precheck": "if [ \"$npm_config_user_agent\" != \"${npm_config_user_agent#*yarn}\" ]; then echo 'Use `npm run shipit` instead of yarn.' && exit 1;  fi",
+    "shipit": "npm run shipit:precheck && yarn build && yarn scriptbundle && yarn minbundle && np",
     "build": "tsc --skipLibCheck",
     "toc": "doctoc .",
     "contributors:add": "all-contributors add",


### PR DESCRIPTION
adding a precheck step to make sure we run npm run shipit before shipping a new build version