### PR TITLE
Only ignore root models folder on npm publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -30,7 +30,7 @@ tsconfig.json
 __tests__/
 
 # Models
-models/
+/models/
 
 # Ignore intermediate browserify files
 # Mountpoint


### PR DESCRIPTION
On MacOS, `.npmignore` file will search globally if you don't have a starting `/` for the root folder.

(fixes: #833)

| Before | After |
| --- | --- |
| <img src="https://github.com/infinitered/nsfwjs/assets/9324607/3490534f-d342-445e-9c9b-8da1ffbb70d3" alt="before" width="300" /> | <img src="https://github.com/infinitered/nsfwjs/assets/9324607/246f3af5-371e-447e-98d7-b17440c3e230" alt="after" width="300" /> |