### PR TITLE
Added trailing slash to Buffer import in index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import * as tf from "@tensorflow/tfjs";
-import { Buffer } from "buffer";
+import { Buffer } from "buffer/";
 import { NSFW_CLASSES } from "./nsfw_classes";
 
 declare global {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import * as tf from "@tensorflow/tfjs";
+// Remove the trailing slash below if this Bun issue gets fixed: https://github.com/oven-sh/bun/issues/8683
 import { Buffer } from "buffer/";
 import { NSFW_CLASSES } from "./nsfw_classes";
 


### PR DESCRIPTION
As recommended by the [Buffer maintainer](https://github.com/feross/buffer?tab=readme-ov-file#usage):

>To require this module explicitly, use require('buffer/') which tells the node.js module lookup algorithm (also used by browserify) to use the npm module named buffer instead of the node.js core module named buffer!

This solves a bug found bundling NSFWJS with Bun.

```
Build failed
1 | import { Buffer } from 'buffer';
             ^
error: No matching export in "node:buffer" for import "Buffer"
    at [path]
```

More information: https://github.com/oven-sh/bun/issues/8683