### PR TITLE
Clean up dist folder before a build to remove any redundant files

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "lint": "tslint -p . -t verbose",
+    "prebuild": "node ./scripts/pre-build.mjs",
     "build:esm": "tsc -p ./tsconfig.esm.json && node ./scripts/add-extensions.mjs",
     "build:cjs": "tsc -p ./tsconfig.cjs.json",
     "build": "yarn build:esm && yarn build:cjs && node ./scripts/add-nested-package-json.mjs",

--- a/scripts/pre-build.mjs
+++ b/scripts/pre-build.mjs
@@ -1,0 +1,5 @@
+import { rmSync } from "fs";
+
+const dir = "./dist";
+
+rmSync(dir, { recursive: true, force: true });

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export type ClassifyConfig = {
   onFrame?: (result: FrameResult) => any;
 };
 
-interface NSFWJSOptions {
+export interface NSFWJSOptions {
   size?: number;
   type?: string;
 }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #905

## What does this PR do?
This removes the additional `models` folder inside `dist` directory that is left behind due to not cleaning up the dist folder before doing a rebuild. This will clean up the dist folder on `prebuild`, which, on the next version of the package, will get rid of the additional models folder that is redundant.

&emsp;\+ This exports the type `NSFWJSOptions`