### PR TITLE
fix: revert trailing slash to Buffer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import * as tf from "@tensorflow/tfjs";
-// Remove the trailing slash below if this Bun issue gets fixed: https://github.com/oven-sh/bun/issues/8683
-import { Buffer } from "buffer/";
+import { Buffer } from "buffer";
 import { NSFW_CLASSES } from "./nsfw_classes";
 
 declare global {


### PR DESCRIPTION
Reverts https://github.com/infinitered/nsfwjs/pull/898 (https://github.com/infinitered/nsfwjs/issues/904)

I am unable to use the project now with ESM due to the trailing slash. Node crashes in runtime:
```
➜  git:(main) ✗ pnpm run build && pnpm run start

> feed-generator@1.0.0 build /Users/...
> tsc


> feed-generator@1.0.0 start /Users/...
> node dist/index.js

node:internal/modules/run_main:122
    triggerUncaughtException(
    ^

Error [ERR_UNSUPPORTED_DIR_IMPORT]: Directory import '/Users//node_modules/.pnpm/nsfwjs@4.2.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__buffer@6.0.3/node_modules/buffer/' is not supported resolving ES modules imported from /Users//node_modules/.pnpm/nsfwjs@4.2.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__buffer@6.0.3/node_modules/nsfwjs/dist/esm/index.js
Did you mean to import "buffer/index.js"?
    at finalizeResolution (node:internal/modules/esm/resolve:251:11)
    at moduleResolve (node:internal/modules/esm/resolve:913:10)
    at defaultResolve (node:internal/modules/esm/resolve:1037:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:650:12)
    at #cachedDefaultResolve (node:internal/modules/esm/loader:599:25)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:582:38)
    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:241:38)
    at ModuleJob._link (node:internal/modules/esm/module_job:132:49) {
  code: 'ERR_UNSUPPORTED_DIR_IMPORT',
  url: 'file:///Users//node_modules/.pnpm/nsfwjs@4.2.1_@tensorflow+tfjs@4.22.0_seedrandom@3.0.5__buffer@6.0.3/node_modules/buffer/'
}

Node.js v22.11.0
```

By removing this temp hack for bun, that they now have fixes, it is working again 