### PR TITLE
fix: CircleCi node version mismatch for eslint 10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,15 +3,15 @@ version: 2.1
 jobs:
   lint:
     docker:
-      - image: cimg/node:20.9.0
+      - image: cimg/node:22.13.0
     steps:
       - checkout
       - restore_cache:
           name: Restore node modules
           keys:
-            - v1-dependencies-{{ checksum "package.json" }}-{{ arch }}
+            - v2-node22.13-dependencies-{{ checksum "package.json" }}-{{ arch }}
             # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
+            - v2-node22.13-dependencies-
       - run:
           name: Install dependencies
           command: yarn install
@@ -19,21 +19,21 @@ jobs:
           name: Save node modules
           paths:
             - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}-{{ arch }}
+          key: v2-node22.13-dependencies-{{ checksum "package.json" }}-{{ arch }}
       - run:
           name: Lint
           command: yarn lint
   test:
     docker:
-      - image: cimg/node:20.9.0
+      - image: cimg/node:22.13.0
     steps:
       - checkout
       - restore_cache:
           name: Restore node modules
           keys:
-            - v1-dependencies-{{ checksum "package.json" }}-{{ arch }}
+            - v2-node22.13-dependencies-{{ checksum "package.json" }}-{{ arch }}
             # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
+            - v2-node22.13-dependencies-
       - run:
           name: Install dependencies
           command: yarn install
@@ -41,7 +41,7 @@ jobs:
           name: Save node modules
           paths:
             - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}-{{ arch }}
+          key: v2-node22.13-dependencies-{{ checksum "package.json" }}-{{ arch }}
       - run:
           name: Test
           command: yarn test

--- a/README.md
+++ b/README.md
@@ -180,7 +180,8 @@ Subsequent Load:
 **Troubleshooting**
 
 - On the tab where the model is being loaded, inspect element and navigate to the the "Application" tab. On the left pane under the "Storage" section, there is a subsection named "IndexedDB". Here you can view if the model is being saved.
-  
+
+For a complete browser worker implementation (including backend initialization, IndexedDB-first load, and save-on-miss caching), see [`examples/nsfw_demo/src/nsfwjs.worker.ts`](./examples/nsfw_demo/src/nsfwjs.worker.ts).
 
 ### `classify` an image
 

--- a/examples/nsfw_demo/src/contexts/NSFWJS/NSFWJSProvider.tsx
+++ b/examples/nsfw_demo/src/contexts/NSFWJS/NSFWJSProvider.tsx
@@ -1,6 +1,6 @@
 import type { ModelName, PredictionType } from "nsfwjs";
-import { useEffect, useState } from "react";
 import type { Dispatch, ReactNode, SetStateAction } from "react";
+import { useEffect, useState } from "react";
 import { NSFWJSContext } from ".";
 import type { Message, ReturnMessage } from "../../nsfwjs.worker";
 
@@ -33,7 +33,9 @@ export const NSFWJSProvider = ({ children }: { children: ReactNode }) => {
 
   useEffect(() => {
     worker.onmessage = (event: MessageEvent<ReturnMessage>) => {
-      const { modelLoaded, predictions } = event.data;
+      const { modelLoaded, predictions, error } = event.data;
+
+      if (error) window.alert(error);
 
       if (modelLoaded !== undefined) {
         setModelLoaded(modelLoaded);

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
   edge_functions = "examples/nsfw_demo/netlify/edge-functions"
 
 [build.environment]
-  NODE_VERSION = "20.19.0"
+NODE_VERSION = "22.13.0"
 
 [[edge_functions]]
   function = "country-block"


### PR DESCRIPTION
This is a patch to pin the node version to 22 in `netlify.toml` and `.circleci/config.yml` to support `eslint 10`.

Also, update the `nsfwjs.worker.ts` in the demo with improvements suggested by Copilot in the previous PR.